### PR TITLE
Threads for dataset processing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,15 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_definitions(-DENABLE_DEBUG_PRINTS)
 endif ()
 
-set(SOURCE_FILES main.cpp)
+set(SOURCE_FILES
+        main.cpp
+        dataset_process.cpp
+)
+
+set(HEADER_FILES
+        dataset_process.hpp
+)
+
 add_executable(OrderBook_run ${SOURCE_FILES})
 
 include_directories(order_book_lib)

--- a/dataset_process.cpp
+++ b/dataset_process.cpp
@@ -19,6 +19,16 @@ uint32_t debug_dummy_volume_ask = 0;
 uint32_t debug_dummy_volume_bid = 0;
 std::string filename = "../example_order_dataset/example_dataset.csv";
 
+// Preprocessor macro definitions
+#ifdef ENABLE_DEBUG_PRINTS
+#define DEBUG_PRINT(x) std::cout << x << std::endl;
+#else
+#define DEBUG_PRINT(x) \
+    do {               \
+    } while (0)
+#endif
+
+
 /*
  * Load the simulated traffic: order messages from a the .csv file created by the data_generator.py to a vector.
  */
@@ -26,7 +36,7 @@ void LoadOrdersFromCSV() {
     std::ifstream file(filename);
 
     if (file.is_open()) {
-        // std::cout << "Example Dataset opened " << filename << std::endl;
+        DEBUG_PRINT("Example Dataset opened " << filename);
         std::string line;
         std::getline(file, line);  // skip the header
 
@@ -86,7 +96,7 @@ void ProcessOrderMessages() {
             std::this_thread::sleep_for(std::chrono::microseconds(10));
         }
 
-        // pop a message
+        // get next order message from spsc queu
         OrderMessage next_order_msg;
         order_messages.pop(next_order_msg);
 

--- a/dataset_process.cpp
+++ b/dataset_process.cpp
@@ -1,0 +1,108 @@
+#include "dataset_process.hpp"
+
+#include <boost/lockfree/spsc_queue.hpp>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "order.hpp"
+#include "order_book.hpp"
+#include "order_utilities.hpp"
+
+boost::lockfree::spsc_queue<OrderMessage> order_messages(1024);
+OrderBook order_book;
+std::atomic<bool> read_in_is_done;
+uint32_t debug_dummy_volume_ask = 0;
+uint32_t debug_dummy_volume_bid = 0;
+std::string filename = "../example_order_dataset/example_dataset.csv";
+
+/*
+ * Load the simulated traffic: order messages from a the .csv file created by the data_generator.py to a vector.
+ */
+void LoadOrdersFromCSV() {
+    std::ifstream file(filename);
+
+    if (file.is_open()) {
+        // std::cout << "Example Dataset opened " << filename << std::endl;
+        std::string line;
+        std::getline(file, line);  // skip the header
+
+        while (std::getline(file, line)) {
+            std::string word;
+            std::stringstream ss(line);
+            OrderMessage next_order_msg;
+            std::string order_message_type_str;
+
+            std::getline(ss, order_message_type_str, ',');
+            if (order_message_type_str == "CancelOrder") {
+                // For cancel order we fill the Order msg type and order id, other fields will not be used.
+                next_order_msg.order_message_type = OrderMessageType::CANCEL_ORDER;
+
+                std::getline(ss, word, ',');
+                next_order_msg.order.orderId = std::stoi(word);
+            } else if (order_message_type_str == "AddOrder") {
+                next_order_msg.order_message_type = OrderMessageType::ADD_ORDER;
+
+                // Fill out the Order part of the Order Message struct.
+                std::getline(ss, word, ',');
+                next_order_msg.order.orderId = std::stoi(word);
+
+                std::getline(ss, word, ',');
+                next_order_msg.order.order_type = StringToOrderType(word);
+
+                std::getline(ss, word, ',');
+                next_order_msg.order.price = std::stoi(word);
+
+                std::getline(ss, word, ',');
+                next_order_msg.order.quantity = std::stoi(word);
+            } else if (order_message_type_str == "GetBestBid") {
+                next_order_msg.order_message_type = OrderMessageType::GET_BEST_BID;
+            } else if (order_message_type_str == "GetAskVolumeBetweenPrices") {
+                next_order_msg.order_message_type = OrderMessageType::GET_ASK_VOLUME_BETWEEN_PRICES;
+                do {
+                    std::getline(ss, word, ',');  // skip empty lines
+                } while (word.empty());
+                next_order_msg.lower_price = std::stoi(word);
+                std::getline(ss, word, ',');
+                next_order_msg.upper_price = std::stoi(word);
+            }
+
+            order_messages.push(next_order_msg);
+        }
+        file.close();
+    } else {
+        std::cout << "Example Dataset File open failed " << filename << std::endl;
+    }
+    read_in_is_done = true;
+}
+
+void ProcessOrderMessages() {
+    while (!read_in_is_done) {
+        // check if single producer single consumer data queue has messages to consume
+        if (order_messages.read_available() == 0) {
+            std::this_thread::sleep_for(std::chrono::microseconds(10));
+        }
+
+        // pop a message
+        OrderMessage next_order_msg;
+        order_messages.pop(next_order_msg);
+
+        if (next_order_msg.order_message_type == OrderMessageType::CANCEL_ORDER) {
+            order_book.CancelOrderbyId(next_order_msg.order.orderId);
+        } else if (next_order_msg.order_message_type == OrderMessageType::ADD_ORDER) {
+            order_book.AddOrder(next_order_msg.order);
+        }
+        // Make sure compiler does not optimize by volatile flag (during benchmark where no dummy).
+        else if (next_order_msg.order_message_type == OrderMessageType::GET_BEST_BID) {
+            volatile std::pair<int, int> my_pair = order_book.GetBestBidWithQuantity();
+            debug_dummy_volume_bid += my_pair.second;
+        } else if (next_order_msg.order_message_type == OrderMessageType::GET_ASK_VOLUME_BETWEEN_PRICES) {
+            volatile uint32_t askVolume =
+                order_book.GetVolumeBetweenPrices(next_order_msg.lower_price, next_order_msg.upper_price);
+            debug_dummy_volume_ask += askVolume;
+        }
+    }
+}

--- a/dataset_process.cpp
+++ b/dataset_process.cpp
@@ -28,7 +28,6 @@ std::string filename = "../example_order_dataset/example_dataset.csv";
     } while (0)
 #endif
 
-
 /*
  * Load the simulated traffic: order messages from a the .csv file created by the data_generator.py to a vector.
  */

--- a/dataset_process.hpp
+++ b/dataset_process.hpp
@@ -1,13 +1,12 @@
 #ifndef DATASET_PROCESS_HPP
 #define DATASET_PROCESS_HPP
 
+#include <atomic>
 #include <boost/lockfree/spsc_queue.hpp>
 #include <string>
-#include <atomic>
+
 #include "order.hpp"
 #include "order_book.hpp"
-
-
 
 // Declare global variables using extern
 extern boost::lockfree::spsc_queue<OrderMessage> order_messages;
@@ -20,6 +19,4 @@ extern std::string filename;
 void ProcessOrderMessages();
 void LoadOrdersFromCSV();
 
-
-
-#endif //DATASET_PROCESS_HPP
+#endif  // DATASET_PROCESS_HPP

--- a/dataset_process.hpp
+++ b/dataset_process.hpp
@@ -1,0 +1,25 @@
+#ifndef DATASET_PROCESS_HPP
+#define DATASET_PROCESS_HPP
+
+#include <boost/lockfree/spsc_queue.hpp>
+#include <string>
+#include <atomic>
+#include "order.hpp"
+#include "order_book.hpp"
+
+
+
+// Declare global variables using extern
+extern boost::lockfree::spsc_queue<OrderMessage> order_messages;
+extern OrderBook order_book;
+extern std::atomic<bool> read_in_is_done;
+extern uint32_t debug_dummy_volume_ask;
+extern uint32_t debug_dummy_volume_bid;
+extern std::string filename;
+
+void ProcessOrderMessages();
+void LoadOrdersFromCSV();
+
+
+
+#endif //DATASET_PROCESS_HPP

--- a/google_benchmark/CMakeLists.txt
+++ b/google_benchmark/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(benchmark)
 set(BENCHMARK_SOURCES
         orderbook_functions_benchmark.cpp
         dataset_processing_benchmark.cpp
+        multithread_dataset_processing_benchmark.cpp
 )
 
 # Adding the benchmark run target

--- a/google_benchmark/CMakeLists.txt
+++ b/google_benchmark/CMakeLists.txt
@@ -10,10 +10,15 @@ set(BENCHMARK_SOURCES
         orderbook_functions_benchmark.cpp
         dataset_processing_benchmark.cpp
         multithread_dataset_processing_benchmark.cpp
+        ${CMAKE_SOURCE_DIR}/dataset_process.cpp
 )
 
 # Adding the benchmark run target
 add_executable(Google_Benchmark_run ${BENCHMARK_SOURCES})
+
+
+# Include main directory for dataset_process.hpp
+target_include_directories(Google_Benchmark_run PRIVATE ${CMAKE_SOURCE_DIR})
 
 # Link the benchmark executable with OrderBook_lib and Google Benchmark
 target_link_libraries(Google_Benchmark_run OrderBook_lib)

--- a/google_benchmark/dataset_processing_benchmark.cpp
+++ b/google_benchmark/dataset_processing_benchmark.cpp
@@ -8,16 +8,10 @@
 
 #include "order.hpp"
 #include "order_book.hpp"
+#include "order_utilities.hpp"
 
 /*  This Google Benchmark file is for measuring the simulated dataset processing
  * run time. */
-
-/* Helper */
-OrderType StringToOrderType(const std::string& str) {
-    if (str == "buy") return OrderType::BUY;
-    if (str == "sell") return OrderType::SELL;
-    return OrderType::UNDEFINED;
-}
 
 /*
  * Load the simulated traffic: order messages from a the .csv file created by
@@ -28,7 +22,6 @@ std::vector<OrderMessage> LoadOrdersFromCSV(const std::string& filename) {
     std::ifstream file(filename);
 
     if (file.is_open()) {
-        std::cout << "Example Dataset opened " << filename << std::endl;
         std::string line;
         std::getline(file, line);  // skip the header
 

--- a/google_benchmark/multithread_dataset_processing_benchmark.cpp
+++ b/google_benchmark/multithread_dataset_processing_benchmark.cpp
@@ -1,112 +1,13 @@
 #include <benchmark/benchmark.h>
 
-#include <boost/lockfree/spsc_queue.hpp>
-#include <fstream>
-#include <iostream>
-#include <sstream>
 #include <string>
 #include <thread>
 
-#include "order.hpp"
-#include "order_book.hpp"
-#include "order_utilities.hpp"
-
-boost::lockfree::spsc_queue<OrderMessage> order_messages(1024);
-OrderBook order_book;
-std::atomic<bool> read_in_is_done;
-uint32_t debug_dummy_volume_ask = 0;
-uint32_t debug_dummy_volume_bid = 0;
-std::string filename = "../../example_order_dataset/example_dataset.csv";
-
-
-/*
- * Load the simulated traffic: order messages from a the .csv file created by the data_generator.py to a vector.
- */
-void LoadOrdersFromCSV() {
-    std::ifstream file(filename);
-
-    if (file.is_open()) {
-        std::string line;
-        std::getline(file, line);  // skip the header
-
-        while (std::getline(file, line)) {
-            std::string word;
-            std::stringstream ss(line);
-            OrderMessage next_order_msg;
-            std::string order_message_type_str;
-
-            std::getline(ss, order_message_type_str, ',');
-            if (order_message_type_str == "CancelOrder") {
-                // For cancel order we fill the Order msg type and order id, other fields will not be used.
-                next_order_msg.order_message_type = OrderMessageType::CANCEL_ORDER;
-
-                std::getline(ss, word, ',');
-                next_order_msg.order.orderId = std::stoi(word);
-            } else if (order_message_type_str == "AddOrder") {
-                next_order_msg.order_message_type = OrderMessageType::ADD_ORDER;
-
-                // Fill out the Order part of the Order Message struct.
-                std::getline(ss, word, ',');
-                next_order_msg.order.orderId = std::stoi(word);
-
-                std::getline(ss, word, ',');
-                next_order_msg.order.order_type = StringToOrderType(word);
-
-                std::getline(ss, word, ',');
-                next_order_msg.order.price = std::stoi(word);
-
-                std::getline(ss, word, ',');
-                next_order_msg.order.quantity = std::stoi(word);
-            } else if (order_message_type_str == "GetBestBid") {
-                next_order_msg.order_message_type = OrderMessageType::GET_BEST_BID;
-            } else if (order_message_type_str == "GetAskVolumeBetweenPrices") {
-                next_order_msg.order_message_type = OrderMessageType::GET_ASK_VOLUME_BETWEEN_PRICES;
-                do {
-                    std::getline(ss, word, ',');  // skip empty lines
-                } while (word.empty());
-                next_order_msg.lower_price = std::stoi(word);
-                std::getline(ss, word, ',');
-                next_order_msg.upper_price = std::stoi(word);
-            }
-
-            order_messages.push(next_order_msg);
-        }
-        file.close();
-    } else {
-        std::cout << "Example Dataset File open failed " << filename << std::endl;
-    }
-    read_in_is_done = true;
-}
-
-void ProcessOrderMessages() {
-    while (!read_in_is_done) {
-        // check if single producer single consumer data queue has messages to consume
-        if (order_messages.read_available() == 0) {
-            continue;
-        }
-
-        // pop a message
-        OrderMessage next_order_msg;
-        order_messages.pop(next_order_msg);
-
-        if (next_order_msg.order_message_type == OrderMessageType::CANCEL_ORDER) {
-            order_book.CancelOrderbyId(next_order_msg.order.orderId);
-        } else if (next_order_msg.order_message_type == OrderMessageType::ADD_ORDER) {
-            order_book.AddOrder(next_order_msg.order);
-        }
-        // Make sure compiler does not optimize by volatile flag (during benchmark where no dummy).
-        else if (next_order_msg.order_message_type == OrderMessageType::GET_BEST_BID) {
-            volatile std::pair<int, int> my_pair = order_book.GetBestBidWithQuantity();
-            debug_dummy_volume_bid += my_pair.second;
-        } else if (next_order_msg.order_message_type == OrderMessageType::GET_ASK_VOLUME_BETWEEN_PRICES) {
-            volatile uint32_t askVolume =
-                order_book.GetVolumeBetweenPrices(next_order_msg.lower_price, next_order_msg.upper_price);
-            debug_dummy_volume_ask += askVolume;
-        }
-    }
-}
+#include "dataset_process.hpp"
 
 static void BM_LoadAndExecuteMessages_MultiThread(benchmark::State& state) {
+    filename = "../../example_order_dataset/example_dataset.csv";
+
     for (auto _ : state) {
         read_in_is_done = false;  // flag for consumer_thread to keep running
         std::thread producer_thread{LoadOrdersFromCSV};

--- a/google_benchmark/orderbook_functions_benchmark.cpp
+++ b/google_benchmark/orderbook_functions_benchmark.cpp
@@ -230,7 +230,7 @@ static void BM_GetAskVolumeBetweenPrices(benchmark::State &state) {
 }
 
 // Add Order Benchmarks
-BENCHMARK(BM_AddOrder_PriceRange_3)->RangeMultiplier(2)->Range(1 << 10, 1 << 20)->Complexity();
+/*BENCHMARK(BM_AddOrder_PriceRange_3)->RangeMultiplier(2)->Range(1 << 10, 1 << 20)->Complexity();
 BENCHMARK(BM_AddOrder_PriceRange_20)->RangeMultiplier(2)->Range(1 << 10, 1 << 20)->Complexity();
 
 // Cancel Order Benchmarks
@@ -242,6 +242,7 @@ BENCHMARK(BM_GetBestBid)->RangeMultiplier(2)->Range(1 << 10, 1 << 20)->Complexit
 
 // Get Ask Volume between Prices Benchmarks
 BENCHMARK(BM_GetAskVolumeBetweenPrices)->RangeMultiplier(2)->Range(1 << 10, 1 << 20)->Complexity();
+*/
 
 // Init and run all BENCHMARK macro registered cases
 BENCHMARK_MAIN();

--- a/google_benchmark/orderbook_functions_benchmark.cpp
+++ b/google_benchmark/orderbook_functions_benchmark.cpp
@@ -230,7 +230,7 @@ static void BM_GetAskVolumeBetweenPrices(benchmark::State &state) {
 }
 
 // Add Order Benchmarks
-/*BENCHMARK(BM_AddOrder_PriceRange_3)->RangeMultiplier(2)->Range(1 << 10, 1 << 20)->Complexity();
+BENCHMARK(BM_AddOrder_PriceRange_3)->RangeMultiplier(2)->Range(1 << 10, 1 << 20)->Complexity();
 BENCHMARK(BM_AddOrder_PriceRange_20)->RangeMultiplier(2)->Range(1 << 10, 1 << 20)->Complexity();
 
 // Cancel Order Benchmarks
@@ -242,7 +242,7 @@ BENCHMARK(BM_GetBestBid)->RangeMultiplier(2)->Range(1 << 10, 1 << 20)->Complexit
 
 // Get Ask Volume between Prices Benchmarks
 BENCHMARK(BM_GetAskVolumeBetweenPrices)->RangeMultiplier(2)->Range(1 << 10, 1 << 20)->Complexity();
-*/
+
 
 // Init and run all BENCHMARK macro registered cases
 BENCHMARK_MAIN();

--- a/main.cpp
+++ b/main.cpp
@@ -6,104 +6,10 @@
 #include <thread>
 #include <vector>
 
+#include "dataset_process.hpp"
 #include "order.hpp"
 #include "order_book.hpp"
 #include "order_utilities.hpp"
-
-boost::lockfree::spsc_queue<OrderMessage> order_messages(1024);
-OrderBook order_book;
-std::atomic<bool> read_in_is_done;
-uint32_t debug_dummy_volume_ask = 0;
-uint32_t debug_dummy_volume_bid = 0;
-std::string filename = "../example_order_dataset/example_dataset.csv";
-
-/*
- * Load the simulated traffic: order messages from a the .csv file created by the data_generator.py to a vector.
- */
-void LoadOrdersFromCSV() {
-    std::ifstream file(filename);
-
-    if (file.is_open()) {
-        std::cout << "Example Dataset opened " << filename << std::endl;
-        std::string line;
-        std::getline(file, line);  // skip the header
-
-        while (std::getline(file, line)) {
-            std::string word;
-            std::stringstream ss(line);
-            OrderMessage next_order_msg;
-            std::string order_message_type_str;
-
-            std::getline(ss, order_message_type_str, ',');
-            if (order_message_type_str == "CancelOrder") {
-                // For cancel order we fill the Order msg type and order id, other fields will not be used.
-                next_order_msg.order_message_type = OrderMessageType::CANCEL_ORDER;
-
-                std::getline(ss, word, ',');
-                next_order_msg.order.orderId = std::stoi(word);
-            } else if (order_message_type_str == "AddOrder") {
-                next_order_msg.order_message_type = OrderMessageType::ADD_ORDER;
-
-                // Fill out the Order part of the Order Message struct.
-                std::getline(ss, word, ',');
-                next_order_msg.order.orderId = std::stoi(word);
-
-                std::getline(ss, word, ',');
-                next_order_msg.order.order_type = StringToOrderType(word);
-
-                std::getline(ss, word, ',');
-                next_order_msg.order.price = std::stoi(word);
-
-                std::getline(ss, word, ',');
-                next_order_msg.order.quantity = std::stoi(word);
-            } else if (order_message_type_str == "GetBestBid") {
-                next_order_msg.order_message_type = OrderMessageType::GET_BEST_BID;
-            } else if (order_message_type_str == "GetAskVolumeBetweenPrices") {
-                next_order_msg.order_message_type = OrderMessageType::GET_ASK_VOLUME_BETWEEN_PRICES;
-                do {
-                    std::getline(ss, word, ',');  // skip empty lines
-                } while (word.empty());
-                next_order_msg.lower_price = std::stoi(word);
-                std::getline(ss, word, ',');
-                next_order_msg.upper_price = std::stoi(word);
-            }
-
-            order_messages.push(next_order_msg);
-        }
-        file.close();
-    } else {
-        std::cout << "Example Dataset File open failed " << filename << std::endl;
-    }
-    read_in_is_done = true;
-}
-
-void ProcessOrderMessages() {
-    while (!read_in_is_done) {
-        // check if single producer single consumer data queue has messages to consume
-        if (order_messages.read_available() == 0) {
-            std::this_thread::sleep_for(std::chrono::microseconds(10));
-        }
-
-        // pop a message
-        OrderMessage next_order_msg;
-        order_messages.pop(next_order_msg);
-
-        if (next_order_msg.order_message_type == OrderMessageType::CANCEL_ORDER) {
-            order_book.CancelOrderbyId(next_order_msg.order.orderId);
-        } else if (next_order_msg.order_message_type == OrderMessageType::ADD_ORDER) {
-            order_book.AddOrder(next_order_msg.order);
-        }
-        // Make sure compiler does not optimize by volatile flag (during benchmark where no dummy).
-        else if (next_order_msg.order_message_type == OrderMessageType::GET_BEST_BID) {
-            volatile std::pair<int, int> my_pair = order_book.GetBestBidWithQuantity();
-            debug_dummy_volume_bid += my_pair.second;
-        } else if (next_order_msg.order_message_type == OrderMessageType::GET_ASK_VOLUME_BETWEEN_PRICES) {
-            volatile uint32_t askVolume =
-                order_book.GetVolumeBetweenPrices(next_order_msg.lower_price, next_order_msg.upper_price);
-            debug_dummy_volume_ask += askVolume;
-        }
-    }
-}
 
 int main() {
     read_in_is_done = false;  // flag for consumer_thread to keep running

--- a/order_book_lib/CMakeLists.txt
+++ b/order_book_lib/CMakeLists.txt
@@ -5,6 +5,7 @@ set(HEADER_FILES
         order_book.hpp
         trade.hpp
         level.hpp
+        order_utilities.hpp
 )
 
 set(SOURCE_FILES

--- a/order_book_lib/order_book.cpp
+++ b/order_book_lib/order_book.cpp
@@ -74,9 +74,9 @@ void OrderBook::AddOrder(Order order) {
     if (order.quantity < 1) {
         throw std::invalid_argument("Quantity must be more than zero.");
     }
-    if (order.orderId <= order_id_tracker_) {
-        throw std::invalid_argument("Order ID must be increasing and uniq number.");
-    }
+    // if (order.orderId <= order_id_tracker_) {
+    //     throw std::invalid_argument("Order ID must be increasing and uniq number.");
+    // }
     if (order.price < 1) {
         throw std::invalid_argument("Price must be more than zero.");
     }

--- a/order_book_lib/order_book.cpp
+++ b/order_book_lib/order_book.cpp
@@ -74,9 +74,9 @@ void OrderBook::AddOrder(Order order) {
     if (order.quantity < 1) {
         throw std::invalid_argument("Quantity must be more than zero.");
     }
-    // if (order.orderId <= order_id_tracker_) {
-    //     throw std::invalid_argument("Order ID must be increasing and uniq number.");
-    // }
+    if (order.orderId <= order_id_tracker_) {
+        throw std::invalid_argument("Order ID must be increasing and uniq number.");
+    }
     if (order.price < 1) {
         throw std::invalid_argument("Price must be more than zero.");
     }

--- a/order_book_lib/order_utilities.hpp
+++ b/order_book_lib/order_utilities.hpp
@@ -1,0 +1,15 @@
+#include <string>
+
+#include "order.hpp"
+#include "order_book.hpp"
+
+#ifndef ORDER_UTILITIES_HPP
+#define ORDER_UTILITIES_HPP
+
+inline OrderType StringToOrderType(const std::string& str) {
+    if (str == "buy") return OrderType::BUY;
+    if (str == "sell") return OrderType::SELL;
+    return OrderType::UNDEFINED;
+}
+
+#endif  // ORDER_UTILITIES_HPP


### PR DESCRIPTION
Use multithreading for datatset processing.
Single Producer Single Consumer lock-free queue as data structure to share data between the two threads:
Producer saves order messages, while Consumer processes the read in messages.
